### PR TITLE
fix: change output directory for Next.js

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,14 +35,11 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Lint Code
-        run: npm run lint
+      - name: Lint & Build
+        run: npm run build
 
       - name: Unit Tests
         run: npm test
-
-      - name: Webpack Build
-        run: npm run build
 
       - name: Setup Pages
         if: github.event_name == 'push'
@@ -52,7 +49,7 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v1
         with:
-          path: "./out/_next"
+          path: "./out"
 
   deploy:
     needs: build


### PR DESCRIPTION
The output folder specified did not target
the correct folder containing the `index.html`
file.

The github workflow also contained a separate
step for linting the code, however, the build
step in the Next.js framework already does this.

refs: #7