### PR TITLE
fix: add .nojekyll file to output

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint & Build
         run: npm run build
 
+      - name: Add .nojekyll File
+        run: touch ./out/.nojekyll
+
       - name: Unit Tests
         run: npm test
 


### PR DESCRIPTION
The `.nojekyll` file will allow github
pages to serve the static js files that
Next.js produces for the static application.

refs: #7