### PR TITLE
fix: .nojekyll not recognized

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,10 +36,9 @@ jobs:
         run: npm ci
 
       - name: Lint & Build
-        run: npm run build
-
-      - name: Add .nojekyll File
-        run: touch ./out/.nojekyll
+        run: |
+          npm run build
+          touch ./out/.nojekyll
 
       - name: Unit Tests
         run: npm test


### PR DESCRIPTION
Trying to combine the build step
that produces the 'out' folder with
the step to generate a `.nojekyll` file
so that it will properly be placed in
the `out` folder when deploying.

refs: #7