### PR TITLE
feat: implement responsive design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# Prefix-Tree Autocomplete 
+# Prefix-Tree Autocomplete
 
 Visually display an autocomplete prefix-tree data structure.
 
 ## Status
+
 [![Continuous Integration](https://github.com/hphothong/prefix-tree-autocomplete/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/hphothong/prefix-tree-autocomplete/actions/workflows/ci-cd.yml)
+
+## Development
+
+```
+npm run dev
+```
+
+Navigate to `https://localhost:3000/prefix-tree-autocomplete`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "prefix-tree-autocomplete",
       "version": "0.1.0",
       "dependencies": {
+        "classnames": "^2.3.2",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -2387,6 +2388,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -9428,6 +9434,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "client-only": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "classnames": "^2.3.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -1,0 +1,11 @@
+.button {
+  padding: 0.25em 1em;
+  border: 1px solid #3377aa;
+  background: #3377cc;
+  color: white;
+  border-radius: 0.25em;
+}
+
+.button:active {
+  background: #224488;
+}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,14 @@
+import React, { ButtonHTMLAttributes, DetailedHTMLProps, FC } from "react";
+import classNames from "classnames";
+import styles from "./Button.module.css";
+
+export type ButtonProps = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;
+
+export const Button: FC<ButtonProps> = ({ className, children, ...props }) => (
+  <button {...props} className={classNames(styles.button, className)}>
+    {children}
+  </button>
+);

--- a/src/components/prefix-tree-view/PrefixTreeView.module.css
+++ b/src/components/prefix-tree-view/PrefixTreeView.module.css
@@ -1,7 +1,6 @@
 .prefixTree {
   display: flex;
   flex-direction: column;
-  align-items: center;
   max-width: 90vw;
   overflow-x: scroll;
   padding: 1rem;

--- a/src/components/prefix-tree-view/PrefixTreeViewNode.tsx
+++ b/src/components/prefix-tree-view/PrefixTreeViewNode.tsx
@@ -1,5 +1,6 @@
 import styles from "./PrefixTreeViewNode.module.css";
 import { PrefixTree, PrefixTreeNode } from "@/common/prefix-tree";
+import classNames from "classnames";
 
 export type PrefixTreeViewNodeProps = {
   prefix: string;
@@ -12,13 +13,13 @@ export default function PrefixTreeViewNode({
 }: PrefixTreeViewNodeProps) {
   const isWord = node[PrefixTree.terminator];
   const title = prefix ? prefix : "root";
+
   return (
     <div className={styles.prefixTreeNodeWrapper}>
       <span
-        className={[
-          styles.prefixTreeNode,
-          isWord && styles.prefixTreeNodeWord,
-        ].join(" ")}
+        className={classNames(styles.prefixTreeNode, {
+          [styles.prefixTreeNodeWord]: isWord,
+        })}
       >
         {title}
       </span>

--- a/src/components/text-input/TextInput.module.css
+++ b/src/components/text-input/TextInput.module.css
@@ -1,11 +1,10 @@
 .inputWrapper {
   display: flex;
-  align-items: center;
+  flex: 1;
   border: 1px solid gray;
   border-radius: 0.25em;
-  padding: 0.0625rem;
-  width: 25vw;
-  height: 4vh;
+  padding: 0.25rem;
+  height: 3vh;
 }
 
 .input {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,6 +1,17 @@
 .main {
   display: flex;
-  flex-direction: column;
-  min-height: 100vh;
   align-items: center;
+  flex-direction: column;
+  min-height: 100%;
+  margin: 1em;
+}
+
+.inputWrapper {
+  display: flex;
+  width: 100%;
+  max-width: 750px;
+}
+
+.addButton {
+  margin-left: 1em;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,10 +4,17 @@ import { usePrefixTree } from "@/common/hooks/usePrefixTree";
 import PrefixTreeView from "@/components/prefix-tree-view/PrefixTreeView";
 import { useState } from "react";
 import TextInput from "@/components/text-input/TextInput";
+import { Button } from "@/components/button/Button";
 
 export default function Home() {
   const [prefix, setPrefix] = useState<string>("");
-  const prefixTree = usePrefixTree();
+  const prefixTree = usePrefixTree([
+    "Welcome",
+    "to",
+    "my",
+    "autocomplete",
+    "project",
+  ]);
 
   function handleAddWord() {
     prefixTree.add(prefix);
@@ -26,7 +33,6 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className={styles.main}>
-        <h1>Prefix Tree Autocomplete</h1>
         <div className={styles.inputWrapper}>
           <TextInput
             placeholder="Enter words to store in the prefix tree..."
@@ -35,6 +41,9 @@ export default function Home() {
             onKeyDown={(e) => e.key === "Enter" && handleAddWord()}
             autoCompleteWords={prefixTree.getWords(prefix, { maxWords: 5 })}
           />
+          <Button className={styles.addButton} onClick={handleAddWord}>
+            Add
+          </Button>
         </div>
         <PrefixTreeView prefixTree={prefixTree} prefix={prefix} />
       </main>


### PR DESCRIPTION
The previous implementation did not work
well with smaller screen sizes. There were
issues with the width of the placeholder
text in the input. There were also issues
with the width of the preview window for the
prefix tree that would cut off certain text.

In addition to fixing responsive design issues,
a button was added to make it more clear that
the input needs to be submitted for the word
to show up in the tree.